### PR TITLE
nn models rewrite

### DIFF
--- a/cybench/datasets/transforms.py
+++ b/cybench/datasets/transforms.py
@@ -1,75 +1,41 @@
 import torch
-from cybench.datasets.dataset import Dataset
-from cybench.datasets.dataset_torch import TorchDataset
 from cybench.util.features import dekad_from_date
-from cybench.config import KEY_DATES
+from cybench.config import (
+    KEY_DATES,
+    TIME_SERIES_PREDICTORS,
+)
 
 
-def _transform_ts_input_to_dekadal(ts_key, value, dates, min_date, max_date):
-    # Transform dates to dekads
+def transform_ts_inputs_to_dekadal(batch, min_date, max_date):
     min_dekad = dekad_from_date(min_date)
     max_dekad = dekad_from_date(max_date)
     dekads = list(range(0, max_dekad - min_dekad + 1))
+    for key in TIME_SERIES_PREDICTORS:
+        value = batch[key]
+        # Transform dates to dekads
+        date_strs = [str(date) for date in batch[KEY_DATES][key]]
+        value_dekads = torch.tensor(
+            [dekad_from_date(date) for date in date_strs], device=value.device
+        )
+        value_dekads -= 1
 
-    datestrings = [str(date) for date in dates]
-    value_dekads = torch.tensor(
-        [dekad_from_date(date) for date in datestrings], device=value.device
-    )
-    value_dekads -= 1
+        # Aggregate timeseries to dekadal resolution
+        new_value = torch.full(
+            (value.shape[0], len(dekads)), float("inf"), dtype=value.dtype
+        )
+        for d in dekads:
+            # Inefficient, but scatter_min or scatter_max are not supported by torch
+            mask = value_dekads == d
+            if value[:, mask].shape[1] == 0:
+                new_value[:, d] = 0.0
+            else:
+                if key in ["tmax"]:  # Max aggregation
+                    new_value[:, d] = value[:, mask].max(dim=1).values
+                elif key in ["tmin"]:  # Min aggregation
+                    new_value[:, d] = value[:, mask].min(dim=1).values
+                else:  # for all other inputs
+                    new_value[:, d] = torch.mean(value[:, mask], dim=1)
 
-    # Aggregate timeseries to dekadal resolution
-    new_value = torch.full(
-        (value.shape[0], len(dekads)), float("inf"), dtype=value.dtype
-    )
-    for d in dekads:
-        # Inefficient, but scatter_min or scatter_max are not supported by torch
-        mask = value_dekads == d
-        if value[:, mask].shape[1] == 0:
-            new_value[:, d] = 0.0
-        else:
-            if ts_key in ["tmax"]:  # Max aggregation
-                new_value[:, d] = value[:, mask].max(dim=1).values
-            elif ts_key in ["tmin"]:  # Min aggregation
-                new_value[:, d] = value[:, mask].min(dim=1).values
-            else:  # for all other inputs
-                new_value[:, d] = torch.mean(value[:, mask], dim=1)
-    return new_value
+        batch[key] = new_value
 
-
-def transform_ts_inputs_to_dekadal(batch_dict, min_date, max_date):
-    out_dict = {}
-    dates = batch_dict[KEY_DATES]
-    for key, value in batch_dict.items():
-        if type(value) == torch.Tensor and len(value.shape) == 2:
-            out_dict[key] = _transform_ts_input_to_dekadal(
-                key, value, dates[key], min_date, max_date
-            )
-        else:
-            out_dict[key] = value
-    return out_dict
-
-
-def transform_stack_ts_static_inputs(batch_dict, min_date, max_date):
-    # Sort values
-    ts = {}
-    static = {}
-    other = {}
-    for key, value in batch_dict.items():
-        if type(value) != torch.Tensor:
-            other[key] = value
-        elif len(value.shape) == 1:
-            static[key] = value
-        else:
-            ts[key] = value
-
-    # Stack values
-    if len(ts) != 0:
-        ts = torch.cat([v.unsqueeze(2) for k, v in ts.items()], dim=2)
-    else:
-        ts = None
-    if len(static) != 0:
-        static = torch.cat([v.unsqueeze(1) for k, v in static.items()], dim=1)
-    else:
-        static = None
-
-    return {"ts": ts, "static": static, "other": other}
+    return batch

--- a/cybench/models/model.py
+++ b/cybench/models/model.py
@@ -35,8 +35,8 @@ class BaseModel(ABC):
         return self.predict_batch(batch, **predict_params)
 
     @abstractmethod
-    def predict_batch(self, X: list, **predict_params):
-        """Run fitted model on batched data items.
+    def predict_items(self, X: list, **predict_params):
+        """Run fitted model on a list of data items.
 
         Args:
           X: a list of data items, each of which is a dict
@@ -46,19 +46,6 @@ class BaseModel(ABC):
           A tuple containing a np.ndarray and a dict with additional information.
         """
         raise NotImplementedError
-
-    def predict_item(self, X: dict, **predict_params):
-        """Run fitted model on one data item.
-
-        Args:
-          X: a data item
-          **predict_params: Additional parameters.
-
-        Returns:
-          A tuple containing a np.ndarray and a dict with additional information.
-        """
-        batch = [X]
-        return self.predict_batch(batch, **predict_params)
 
     @abstractmethod
     def save(self, model_name):

--- a/cybench/models/model.py
+++ b/cybench/models/model.py
@@ -32,7 +32,7 @@ class BaseModel(ABC):
           A tuple containing a np.ndarray and a dict with additional information.
         """
         batch = [d for d in dataset]
-        return self.predict_batch(batch, **predict_params)
+        return self.predict_items(batch, **predict_params)
 
     @abstractmethod
     def predict_items(self, X: list, **predict_params):

--- a/cybench/models/naive_models.py
+++ b/cybench/models/naive_models.py
@@ -45,8 +45,8 @@ class AverageYieldModel(BaseModel):
 
         return self, {}
 
-    def predict_batch(self, X: list):
-        """Run fitted model on batched data items.
+    def predict_items(self, X: list):
+        """Run fitted model on a list of data items.
 
         Args:
           X: a list of data items, each of which is a dict

--- a/cybench/models/nn_models.py
+++ b/cybench/models/nn_models.py
@@ -423,8 +423,8 @@ class BaseNNModel(BaseModel, nn.Module):
 
         return inputs
 
-    def predict_batch(self, X: list, device: str = "cpu", **predict_params):
-        """Run fitted model on batched data items.
+    def predict_items(self, X: list, device: str = "cpu", **predict_params):
+        """Run fitted model on a list of data items.
 
         Args:
           X: a list of data items, each of which is a dict

--- a/cybench/models/sklearn_model.py
+++ b/cybench/models/sklearn_model.py
@@ -185,8 +185,8 @@ class SklearnModel(BaseModel):
 
         return self._est.predict(X_test), {}
 
-    def predict_batch(self, X: list):
-        """Run fitted model on batched data items.
+    def predict_items(self, X: list):
+        """Run fitted model on a list of data items.
 
         Args:
           X: a list of data items, each of which is a dict

--- a/cybench/models/trend_model.py
+++ b/cybench/models/trend_model.py
@@ -26,7 +26,7 @@ class TrendModel(BaseModel):
         Args:
           trend_x: a list of years.
           trend_y: a list of values (e.g. yields)
-          pred_x: year for which to predict trend
+
         Returns:
           A linear trend estimator
         """
@@ -55,6 +55,7 @@ class TrendModel(BaseModel):
         Args:
           dataset: Dataset
           **fit_params: Additional parameters.
+
         Returns:
           A tuple containing the fitted model and a dict with additional information.
         """
@@ -89,10 +90,11 @@ class TrendModel(BaseModel):
 
         return self, {}
 
-    def predict_batch(self, X: list):
-        """Run fitted model on batched data items.
+    def predict_items(self, X: list):
+        """Run fitted model on a list of data items.
         Args:
           X: a list of data items, each of which is a dict
+
         Returns:
           A tuple containing a np.ndarray and a dict with additional information.
         """

--- a/cybench/runs/agml_workshop.py
+++ b/cybench/runs/agml_workshop.py
@@ -1,0 +1,388 @@
+import os
+import logging
+import pandas as pd
+import numpy as np
+import random
+import torch
+from torch import nn
+
+from cybench.datasets.dataset_torch import TorchDataset
+from cybench.models.model import BaseModel
+from cybench.models.nn_models import ExampleLSTM
+from cybench.evaluation.eval import normalized_rmse, evaluate_predictions
+
+from cybench.config import (
+    PATH_DATA_DIR,
+    PATH_OUTPUT_DIR,
+    KEY_LOC,
+    KEY_YEAR,
+    KEY_TARGET,
+    METEO_INDICATORS,
+    RS_FPAR,
+)
+
+STATIC_PREDICTORS = ["awc"]
+TIME_SERIES_PREDICTORS = METEO_INDICATORS + [RS_FPAR]
+
+
+class LSTMModel(BaseModel, nn.Module):
+    def __init__(
+        self, num_rnn_layers=1, rnn_hidden_size=64, num_outputs=1, *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        num_ts_inputs = len(TIME_SERIES_PREDICTORS)
+        num_other_inputs = len(STATIC_PREDICTORS)
+        self._batch_norm1 = nn.BatchNorm1d(num_ts_inputs)
+        self._rnn = nn.LSTM(
+            input_size=num_ts_inputs,
+            hidden_size=rnn_hidden_size,
+            num_layers=num_rnn_layers,
+            batch_first=True,
+        )
+
+        num_all_inputs = rnn_hidden_size + num_other_inputs
+        self._batch_norm2 = nn.BatchNorm1d(num_all_inputs)
+        self._fc = nn.Linear(num_all_inputs, num_outputs)
+        self._logger = logging.getLogger(__name__)
+
+    def fit(
+        self, train_dataset, optimize_hyperparameters=False, epochs=10, **fit_params
+    ):
+        self.train()
+        batch_size = 16
+        loss = nn.MSELoss()
+        if optimize_hyperparameters:
+            # Hyperparameter optimization
+            os.makedirs(os.path.join(PATH_OUTPUT_DIR, "saved_models"), exist_ok=True)
+            save_model_path = os.path.join(
+                PATH_OUTPUT_DIR, "saved_models", "saved_lstm_model"
+            )
+            torch.save(self.state_dict(), save_model_path)
+            param_space = {"lr": [0.0001, 0.00005], "weight_decay": [0.0001, 0.00001]}
+            opt_hparams = self._optimize_hyperparameters(
+                train_dataset,
+                param_space,
+                loss,
+                batch_size,
+                epochs,
+                save_model_path,
+            )
+            sel_lr = opt_hparams["lr"]
+            sel_wt_decay = opt_hparams["weight_decay"]
+
+            # load saved model to retrain with optimal hyperparameters
+            self.load_state_dict(torch.load(save_model_path))
+        else:
+            sel_lr = 0.0001
+            sel_wt_decay = 0.0001
+
+        torch_dataset = TorchDataset(train_dataset)
+        data_loader = torch.utils.data.DataLoader(
+            torch_dataset,
+            collate_fn=torch_dataset.collate_fn,
+            shuffle=True,
+            batch_size=batch_size,
+        )
+        optimizer = torch.optim.Adam(
+            self.parameters(), lr=sel_lr, weight_decay=sel_wt_decay
+        )
+
+        for epoch in range(epochs):
+            train_metrics = self._train_epoch(data_loader, loss, optimizer)
+            self._logger.debug(
+                "LSTMModel epoch:%d, loss:%f, NRMSE:%f",
+                epoch,
+                train_metrics["loss"],
+                train_metrics["train NRMSE"],
+            )
+
+    def _train_epoch(self, train_loader, loss, optimizer):
+        epoch_loss = 0
+        num_elems = 0
+        y_all = None
+        y_hat_all = None
+        for batch in train_loader:
+            y = torch.unsqueeze(batch[KEY_TARGET], 1)
+            X_ts = torch.cat(
+                [torch.unsqueeze(batch[c], 1) for c in TIME_SERIES_PREDICTORS], dim=1
+            )
+            X_rest = torch.cat(
+                [torch.unsqueeze(batch[c], 1) for c in STATIC_PREDICTORS], dim=1
+            )
+
+            y_hat = self(X_ts, X_rest)
+            l = loss(y_hat, y)
+            optimizer.zero_grad()
+            l.backward()
+            optimizer.step()
+            epoch_loss += float(l)
+            num_elems += y.size().numel()
+
+            if y_all is None:
+                y_all = y
+                y_hat_all = y_hat
+            else:
+                y_all = torch.cat([y_all, y], dim=0)
+                y_hat_all = torch.cat([y_hat_all, y_hat], dim=0)
+
+        train_nrmse = (
+            100 * torch.sqrt(torch.mean((y_hat_all - y_all) ** 2)) / torch.mean(y_all)
+        )
+
+        return {"loss": epoch_loss / num_elems, "train NRMSE": train_nrmse.item()}
+
+    def _optimize_hyperparameters(
+        self,
+        train_dataset,
+        param_space,
+        loss,
+        batch_size,
+        epochs,
+        save_model_path,
+    ):
+        train_years = train_dataset.years
+        # year_splits = [(list(range(2000, 2012)), list(range(2013, 2018)))]
+        year_splits = self._get_validation_splits(
+            train_years, num_folds=1, num_valid_years=5
+        )
+        self._logger.debug("Year splits for hyperparameter optimization")
+        for i, (train_years2, valid_years) in enumerate(year_splits):
+            self._logger.debug("Split %d Training years: %s", i, train_years2)
+            self._logger.debug("Split %d Validation years: %s", i, valid_years)
+
+        optimal_hparams = {}
+        for param in param_space:
+            optimal_hparams[param] = None
+
+        lowest_nrmse = None
+        for lr in param_space["lr"]:
+            for wt_decay in param_space["weight_decay"]:
+                cv_nrmses = np.zeros(len(year_splits))
+                for i, (train_years2, valid_years) in enumerate(year_splits):
+                    train_dataset2, valid_dataset = train_dataset.split_on_years(
+                        (train_years2, valid_years)
+                    )
+                    torch_dataset = TorchDataset(train_dataset2)
+                    data_loader = torch.utils.data.DataLoader(
+                        torch_dataset,
+                        collate_fn=torch_dataset.collate_fn,
+                        shuffle=True,
+                        batch_size=batch_size,
+                    )
+                    optimizer = torch.optim.Adam(
+                        self.parameters(), lr=lr, weight_decay=wt_decay
+                    )
+                    self.load_state_dict(torch.load(save_model_path))
+                    valid_nrmse = None
+                    for epoch in range(epochs):
+                        metrics = self._train_epoch(data_loader, loss, optimizer)
+                        y_pred = self.predict(valid_dataset)
+                        y_true = valid_dataset.targets
+                        valid_nrmse = normalized_rmse(y_true, y_pred)
+                        metrics["valid NRMSE"] = valid_nrmse
+
+                    # Using valid_nrmse from the last epoch
+                    cv_nrmses[i] = valid_nrmse
+
+                avg_nrmse = np.mean(cv_nrmses)
+                self._logger.debug(
+                    "LSTMModel lr:%f, wt_decay:%f, avg NRMSE:%f",
+                    lr,
+                    wt_decay,
+                    avg_nrmse,
+                )
+
+                if (lowest_nrmse is None) or (avg_nrmse < lowest_nrmse):
+                    lowest_nrmse = avg_nrmse
+                    optimal_hparams["lr"] = lr
+                    optimal_hparams["weight_decay"] = wt_decay
+
+        self._logger.debug(
+            "LSTMModel Optimal lr:%f, wt_decay:%f, avg NRMSE %f",
+            optimal_hparams["lr"],
+            optimal_hparams["weight_decay"],
+            lowest_nrmse,
+        )
+
+        return optimal_hparams
+
+    def _get_validation_splits(self, all_years, num_folds=1, num_valid_years=5):
+        year_splits = []
+        assert len(all_years) >= (num_folds * num_valid_years)
+        if num_folds > 1:
+            random.shuffle(all_years)
+
+        for i in range(num_folds):
+            valid_years = all_years[i * num_valid_years : (i + 1) * num_valid_years]
+            train_years = [yr for yr in all_years if yr not in valid_years]
+            year_splits.append((train_years, valid_years))
+
+        return year_splits
+
+    def predict_items(
+        self,
+        X: list,
+        device: str = "cuda" if torch.cuda.is_available() else "cpu",
+        **predict_params,
+    ):
+        """Run fitted model on a list of data items.
+
+        Args:
+          X (list): a list of data items, each of which is a dict
+          device (str): str, the device to use
+          **predict_params: Additional parameters
+
+        Returns:
+          A tuple containing a np.ndarray and a dict with additional information.
+        """
+        self.to(device)
+        self.eval()
+
+        with torch.no_grad():
+            X_collated = TorchDataset.collate_fn(
+                [TorchDataset._cast_to_tensor(x) for x in X]
+            )
+            y_pred = self._forward_pass(X_collated, device)
+            y_pred = y_pred.cpu().numpy()
+            return y_pred, {}
+
+    def predict(self, test_dataset):
+        self.eval()
+        torch_dataset = TorchDataset(test_dataset)
+        data_loader = torch.utils.data.DataLoader(
+            torch_dataset,
+            collate_fn=torch_dataset.collate_fn,
+            shuffle=False,
+            batch_size=16,
+        )
+
+        with torch.no_grad():
+            predictions = None
+            for batch in data_loader:
+                X_ts = torch.cat(
+                    [torch.unsqueeze(batch[c], 1) for c in TIME_SERIES_PREDICTORS],
+                    dim=1,
+                )
+                X_rest = torch.cat(
+                    [torch.unsqueeze(batch[c], 1) for c in STATIC_PREDICTORS], dim=1
+                )
+                batch_preds = self(X_ts, X_rest)
+                if batch_preds.dim() > 1:
+                    batch_preds = batch_preds.squeeze(-1)
+
+                if predictions is None:
+                    predictions = batch_preds.cpu().numpy()
+                else:
+                    predictions = np.concatenate((predictions, batch_preds), axis=0)
+
+            # set mode to train
+            self.train()
+            return predictions, {}
+
+    def forward(self, X_ts, X_rest):
+        X_ts_norm = self._batch_norm1(X_ts)
+        # self._rnn expects (batch, sequence, input variables)
+        _, ts_state = self._rnn(X_ts_norm.permute(0, 2, 1))
+        ts_h_out = ts_state[0][self._rnn.num_layers - 1].view(-1, self._rnn.hidden_size)
+
+        all_inputs = self._batch_norm2(torch.cat([ts_h_out, X_rest], 1))
+        return self._fc(all_inputs)
+
+    def save(self, model_name):
+        torch.save(self, model_name)
+
+    @classmethod
+    def load(cls, model_name):
+        return torch.load(model_name)
+
+
+def date_from_dekad(dekad, year):
+    date_str = str(year)
+    month = int(np.ceil(dekad / 3))
+    if month < 10:
+        date_str += "0" + str(month)
+    else:
+        date_str += str(month)
+
+    if dekad % 3 == 1:
+        date_str += "01"
+    elif dekad % 3 == 2:
+        date_str += "11"
+    else:
+        date_str += "21"
+
+    return date_str
+
+
+from cybench.datasets.alignment import align_data
+from cybench.datasets.dataset import Dataset
+
+
+if __name__ == "__main__":
+    path_data_cn = os.path.join(PATH_DATA_DIR, "workshop-data")
+    df_y = pd.read_csv(os.path.join(path_data_cn, "yield_maize_US.csv"), header=0)
+    # convert maize (corn) yield from bushels/acre to t/ha
+    # See https://www.extension.iastate.edu/agdm/wholefarm/html/c6-80.html
+    df_y[KEY_TARGET] = 0.0628 * df_y[KEY_TARGET]
+    df_y = df_y.rename(columns={"harvest_year": KEY_YEAR})
+    df_y.set_index([KEY_LOC, KEY_YEAR], inplace=True)
+
+    df_crop_cal = pd.read_csv(
+        os.path.join(path_data_cn, "crop_calendar_maize_US.csv"), header=0
+    )
+    season_start = int(df_crop_cal["sos"].mean())
+    season_end = int(df_crop_cal["eos"].mean())
+    dfs_x = []
+    for input in ["soil", "meteo", "fpar"]:
+        df_x = pd.read_csv(
+            os.path.join(path_data_cn, input + "_maize_US.csv"), header=0
+        )
+        if input == "soil":
+            df_x = df_x[[KEY_LOC, "awc"]]
+            df_x.set_index([KEY_LOC], inplace=True)
+        else:
+            # lead time = 6 dekads
+            df_x = df_x[df_x["dekad"] <= 30]
+            df_x["date"] = df_x.apply(
+                lambda r: date_from_dekad(r["dekad"], r["year"]), axis=1
+            )
+            df_x = df_x.drop(columns=["dekad"])
+            df_x.set_index([KEY_LOC, KEY_YEAR, "date"], inplace=True)
+            if input == "meteo":
+                df_x["cwb"] = df_x["prec"] = df_x["et0"]
+                df_x = df_x[METEO_INDICATORS]
+
+        dfs_x.append(df_x)
+
+    df_y, dfs_x = align_data(df_y, dfs_x)
+    dataset = Dataset("maize", df_y, dfs_x)
+    all_years = dataset.years
+    test_years = [2012, 2018]
+    train_years = [yr for yr in all_years if yr not in test_years]
+    train_dataset, test_dataset = dataset.split_on_years((train_years, test_years))
+    test_labels = test_dataset.targets()
+
+    model_output = {
+        KEY_LOC: [loc_id for loc_id, _ in test_dataset.indices()],
+        KEY_YEAR: [year for _, year in test_dataset.indices()],
+        "targets": test_labels,
+    }
+
+    for model_name in ["workshop_lstm", "benchmark_lstm"]:
+        if model_name == "workshop_lstm":
+            lstm_model = LSTMModel()
+        else:
+            # NOTE: config.py requires these updates to test with ExampleLSTM.
+            # 1. SOIL_PROPERTIES = ["awc"]
+            # 2. TIME_SERIES_PREDICTORS = METEO_INDICATORS + [RS_FPAR]
+            # The workshop data does not include other inputs from the benchmark.
+            lstm_model = ExampleLSTM(transforms=[])
+
+        lstm_model.fit(train_dataset, epochs=10)
+        test_preds, _ = lstm_model.predict(test_dataset)
+        model_output[model_name] = test_preds
+        results = evaluate_predictions(test_labels, test_preds)
+        print(model_name, results)
+
+    pred_df = pd.DataFrame.from_dict(model_output)
+    print(pred_df.head())

--- a/cybench/runs/run_benchmark.py
+++ b/cybench/runs/run_benchmark.py
@@ -40,6 +40,9 @@ BASELINE_MODELS = list(_BASELINE_MODEL_CONSTRUCTORS.keys())
 _BASELINE_MODEL_INIT_KWARGS = defaultdict(dict)
 _BASELINE_MODEL_INIT_KWARGS["LinearTrend"] = {"trend": "linear"}
 
+_BASELINE_MODEL_INIT_KWARGS["SklearnRidge"] = {"sklearn_est": sklearn_ridge}
+_BASELINE_MODEL_INIT_KWARGS["SklearnRF"] = {"sklearn_est": sklearn_rf}
+
 _BASELINE_MODEL_INIT_KWARGS["LSTM"] = {
     "hidden_size": 64,
     "num_layers": 1,

--- a/cybench/runs/run_benchmark.py
+++ b/cybench/runs/run_benchmark.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 
 import pandas as pd
 import torch
-from datetime import datetime
 from sklearn.linear_model import Ridge
 from sklearn.ensemble import RandomForestRegressor
 
@@ -16,9 +15,7 @@ from cybench.config import (
 )
 
 from cybench.datasets.dataset import Dataset
-
 from cybench.evaluation.eval import evaluate_predictions
-
 from cybench.models.naive_models import AverageYieldModel
 from cybench.models.trend_model import TrendModel
 from cybench.models.sklearn_model import SklearnModel
@@ -43,23 +40,8 @@ _BASELINE_MODEL_INIT_KWARGS["LinearTrend"] = {"trend": "linear"}
 _BASELINE_MODEL_INIT_KWARGS["SklearnRidge"] = {"sklearn_est": sklearn_ridge}
 _BASELINE_MODEL_INIT_KWARGS["SklearnRF"] = {"sklearn_est": sklearn_rf}
 
-_BASELINE_MODEL_INIT_KWARGS["LSTM"] = {
-    "hidden_size": 64,
-    "num_layers": 1,
-}
-
 _BASELINE_MODEL_FIT_KWARGS = defaultdict(dict)
-_BASELINE_MODEL_FIT_KWARGS["SklearnRidge"] = {
-    "select_features": True,
-    "optimize_hyperparameters": True,
-}
-
-_BASELINE_MODEL_FIT_KWARGS["SklearnRF"] = {
-    "optimize_hyperparameters": True,
-}
-
 _BASELINE_MODEL_FIT_KWARGS["LSTM"] = {
-    "optimize_hyperparameters": False,
     "device": "cuda" if torch.cuda.is_available() else "cpu",
 }
 
@@ -84,6 +66,7 @@ def run_benchmark(
         baseline_models (list): A list of names of baseline models to run next to the provided model.
                                 If unspecified, a default list of baseline models will be used.
         dataset_name (str): The name of the dataset to load
+
     Returns:
         a dictionary containing the results of the benchmark
     """
@@ -162,6 +145,14 @@ def run_benchmark(
 def load_results(
     run_name: str,
 ) -> pd.DataFrame:
+    """
+    Load saved results for analysis or visualization.
+    Args:
+        run_name (str): The name of the run. Will be used to store log files and model results
+
+    Returns:
+        a pd.DataFrame containing the predictions of benchmark models
+    """
     path_results = os.path.join(PATH_RESULTS_DIR, run_name)
 
     files = [
@@ -184,6 +175,15 @@ def load_results(
 
 
 def get_prediction_residuals(run_name: str, model_names: dict) -> pd.DataFrame:
+    """
+    Get prediction residuals (i.e., model predictions - labels).
+    Args:
+        run_name (str): The name of the run. Will be used to store log files and model results
+        model_names (dict): A mapping of model name (key) to a shorter name (value)
+
+    Returns:
+        a pd.DataFrame containing prediction residuals
+    """
     df_all = load_results(run_name)
     if df_all.empty:
         return df_all
@@ -200,6 +200,15 @@ def compute_metrics(
     run_name: str,
     model_names: list,
 ) -> pd.DataFrame:
+    """
+    Compute evaluation metrics on saved predictions.
+    Args:
+        run_name (str): The name of the run. Will be used to store log files and model results
+        model_names (list) : names of models
+
+    Returns:
+        a pd.DataFrame containing evaluation metrics
+    """
     df_all = load_results(run_name)
     if df_all.empty:
         return pd.DataFrame(columns=["model", "year"])

--- a/cybench/runs/run_benchmark.py
+++ b/cybench/runs/run_benchmark.py
@@ -17,7 +17,7 @@ from cybench.config import (
 
 from cybench.datasets.dataset import Dataset
 
-from cybench.evaluation.eval import evaluate_model, evaluate_predictions
+from cybench.evaluation.eval import evaluate_predictions
 
 from cybench.models.naive_models import AverageYieldModel
 from cybench.models.trend_model import TrendModel
@@ -40,19 +40,19 @@ BASELINE_MODELS = list(_BASELINE_MODEL_CONSTRUCTORS.keys())
 _BASELINE_MODEL_INIT_KWARGS = defaultdict(dict)
 _BASELINE_MODEL_INIT_KWARGS["LinearTrend"] = {"trend": "linear"}
 
-_BASELINE_MODEL_INIT_KWARGS["SklearnRidge"] = {"sklearn_est": sklearn_ridge}
-_BASELINE_MODEL_INIT_KWARGS["SklearnRF"] = {"sklearn_est": sklearn_rf}
-
 _BASELINE_MODEL_INIT_KWARGS["LSTM"] = {
     "hidden_size": 64,
     "num_layers": 1,
 }
 
 _BASELINE_MODEL_FIT_KWARGS = defaultdict(dict)
-
 _BASELINE_MODEL_FIT_KWARGS["SklearnRidge"] = {
+    "select_features": True,
     "optimize_hyperparameters": True,
-    "param_space": {"estimator__alpha": [0.01, 0.1, 0.0, 1.0, 5.0, 10.0]},
+}
+
+_BASELINE_MODEL_FIT_KWARGS["SklearnRF"] = {
+    "optimize_hyperparameters": True,
 }
 
 _BASELINE_MODEL_FIT_KWARGS["LSTM"] = {
@@ -184,7 +184,6 @@ def load_results(
         if os.path.isfile(os.path.join(path_results, f))
     ]
 
-    print(files)
     # No files, return an empty data frame
     if not files:
         return pd.DataFrame(columns=[KEY_LOC, KEY_YEAR, "targets"])

--- a/cybench/runs/run_benchmark.py
+++ b/cybench/runs/run_benchmark.py
@@ -60,6 +60,7 @@ _BASELINE_MODEL_FIT_KWARGS["SklearnRF"] = {
 
 _BASELINE_MODEL_FIT_KWARGS["LSTM"] = {
     "optimize_hyperparameters": False,
+    "device": "cuda" if torch.cuda.is_available() else "cpu",
 }
 
 

--- a/cybench/runs/run_benchmark.py
+++ b/cybench/runs/run_benchmark.py
@@ -56,25 +56,7 @@ _BASELINE_MODEL_FIT_KWARGS["SklearnRF"] = {
 }
 
 _BASELINE_MODEL_FIT_KWARGS["LSTM"] = {
-    "batch_size": 16,
-    "num_epochs": 50,
-    "device": "cuda" if torch.cuda.is_available() else "cpu",
-    "optim_fn": torch.optim.Adam,
-    "optim_kwargs": {"lr": 0.0001, "weight_decay": 0.00001},
-    "scheduler_fn": torch.optim.lr_scheduler.StepLR,
-    "scheduler_kwargs": {"step_size": 1, "gamma": 1},
-    "val_fraction": 0.1,
-    "val_split_by_year": True,
-    "do_early_stopping": True,
     "optimize_hyperparameters": False,
-    "param_space": {
-        "optim_kwargs": {
-            "lr": [0.0001, 0.00001],
-            "weight_decay": [0.0001, 0.00001],
-        },
-    },
-    "do_kfold": False,
-    "kfolds": 5,
 }
 
 

--- a/cybench/util/data.py
+++ b/cybench/util/data.py
@@ -1,6 +1,4 @@
-import copy
 import pandas as pd
-from sklearn.model_selection import ParameterGrid
 
 
 def data_to_pandas(data_items, data_cols=None):
@@ -21,54 +19,3 @@ def data_to_pandas(data_items, data_cols=None):
         data.append([item[c] for c in data_cols])
 
     return pd.DataFrame(data, columns=data_cols)
-
-
-def flatten_nested_dict(d, parent_key="", sep="."):
-    items = []
-    for k, v in d.items():
-        new_key = f"{parent_key}{sep}{k}" if parent_key else k
-        if isinstance(v, dict):
-            items.extend(flatten_nested_dict(v, new_key, sep=sep).items())
-        else:
-            items.append((new_key, v))
-    return dict(items)
-
-
-def unflatten_nested_dict(d, sep="."):
-    out = {}
-    for k, v in d.items():
-        keys = k.split(sep)
-        if len(keys) == 1:
-            out[k] = v
-        else:
-            new_key = keys[0]
-            new_subkey = sep.join(keys[1:])
-            if new_key not in out:
-                out[new_key] = {}
-            out[new_key][new_subkey] = v
-    for k, v in out.items():
-        if isinstance(v, dict):
-            out[k] = unflatten_nested_dict(v, sep=sep)
-    return out
-
-
-def update_settings(new_settings: dict, standard_settings: dict):
-    new_settings = flatten_nested_dict(new_settings)
-    standard_settings = copy.deepcopy(standard_settings)
-    standard_settings = flatten_nested_dict(standard_settings)
-    standard_settings.update(new_settings)
-    standard_settings = unflatten_nested_dict(standard_settings)
-    return standard_settings
-
-
-def generate_settings(param_space: dict, standard_settings: dict):
-    settings = []
-    param_space = flatten_nested_dict(param_space)
-    standard_settings = flatten_nested_dict(standard_settings)
-    combs = list(ParameterGrid(param_space))
-    for comb in combs:
-        setting = copy.deepcopy(standard_settings)
-        setting.update(comb)
-        settings.append(setting)
-    settings = [unflatten_nested_dict(setting) for setting in settings]
-    return settings

--- a/tests/datasets/test_transforms.py
+++ b/tests/datasets/test_transforms.py
@@ -2,7 +2,6 @@ from cybench.datasets.dataset import Dataset
 from cybench.datasets.dataset_torch import TorchDataset
 from cybench.datasets.transforms import (
     transform_ts_inputs_to_dekadal,
-    transform_stack_ts_static_inputs,
 )
 
 from cybench.config import TIME_SERIES_PREDICTORS
@@ -15,7 +14,7 @@ def test_transforms():
     train_dataset = TorchDataset(train_dataset)
     batch = [train_dataset[i] for i in range(16)]
     batch = TorchDataset.collate_fn(batch).copy()
-    transforms = [transform_ts_inputs_to_dekadal, transform_stack_ts_static_inputs]
+    transforms = [transform_ts_inputs_to_dekadal]
     for i, transform in enumerate(transforms):
         batch = transform(batch, min_date, max_date)
         # check time series transfomations

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -44,7 +44,7 @@ def test_average_yield_model():
         KEY_YEAR: sel_year,
     }
 
-    test_preds, _ = model.predict_item(test_data)
+    test_preds, _ = model.predict_items([test_data])
     assert np.round(test_preds[0], 2) == np.round(expected_pred, 2)
 
     # test one more location
@@ -52,7 +52,7 @@ def test_average_yield_model():
     test_data[KEY_LOC] = sel_loc
     filtered_df = yield_df[yield_df.index.get_level_values(0) == sel_loc]
     expected_pred = filtered_df[KEY_TARGET].mean()
-    test_preds, _ = model.predict_item(test_data)
+    test_preds, _ = model.predict_items([test_data])
     assert np.round(test_preds[0], 2) == np.round(expected_pred, 2)
 
     # test prediction for a non-existent item
@@ -62,7 +62,7 @@ def test_average_yield_model():
     model.fit(dataset)
     expected_pred = yield_df[KEY_TARGET].mean()
     test_data[KEY_LOC] = sel_loc
-    test_preds, _ = model.predict_item(test_data)
+    test_preds, _ = model.predict_items([test_data])
     assert np.round(test_preds[0], 2) == np.round(expected_pred, 2)
 
 
@@ -128,14 +128,14 @@ def test_trend_model():
                     KEY_LOC: sel_loc,
                     KEY_YEAR: test_year,
                 }
-                test_preds, _ = model.predict_item(test_data)
+                test_preds, _ = model.predict_items([test_data])
                 expected_pred = test_yields[KEY_TARGET].values[0]
                 assert np.round(test_preds[0], 2) == np.round(expected_pred, 2)
 
                 # quadratic trend ( trend = c + a x + b x^2)
                 model = TrendModel(trend="quadratic")
                 model.fit(train_dataset)
-                test_preds, _ = model.predict_item(test_data)
+                test_preds, _ = model.predict_items([test_data])
                 expected_pred = test_yields[KEY_TARGET].values[0]
                 assert np.round(test_preds[0], 2) == np.round(expected_pred, 2)
         else:
@@ -152,7 +152,7 @@ def test_trend_model():
                 KEY_LOC: sel_loc,
                 KEY_YEAR: test_year,
             }
-            test_preds, _ = model.predict_item(test_data)
+            test_preds, _ = model.predict_items([test_data])
             expected_pred = train_yields[KEY_TARGET].mean()
             assert np.round(test_preds[0], 2) == np.round(expected_pred, 2)
 
@@ -271,10 +271,10 @@ def test_nn_model():
         },
     )
 
-    # Test predict_batch
+    # Test predict_items()
     num_test_items = len(test_dataset)
     test_data = [test_dataset[i] for i in range(min(num_test_items, 16))]
-    test_preds, _ = model.predict_batch(test_data)
+    test_preds, _ = model.predict_items(test_data)
     assert test_preds.shape[0] == min(num_test_items, 16)
 
     # Check if evaluation results are within expected range

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -242,7 +242,7 @@ def test_nn_model():
     # Initialize model, assumes that all features are in np.ndarray format
     model = ExampleLSTM(
         hidden_size=64,
-        num_layers=2,
+        num_layers=1,
         output_size=1,
     )
     scheduler_fn = torch.optim.lr_scheduler.StepLR
@@ -251,12 +251,23 @@ def test_nn_model():
     # Train model
     model.fit(
         train_dataset,
-        batch_size=3200,
-        num_epochs=2,
+        batch_size=16,
+        num_epochs=5,
+        param_space = {
+            "optim_kwargs": {
+                "lr": [0.0001, 0.00001],
+                "weight_decay": [0.0001, 0.00001],
+            },
+        },
         device=device,
         optim_kwargs={"lr": 0.01},
         scheduler_fn=scheduler_fn,
         scheduler_kwargs=scheduler_kwargs,
+        **{
+            "optimize_hyperparameters": True,
+            "do_kfold": True,
+            "kfolds": 1,
+        }
     )
 
     test_preds, _ = model.predict(test_dataset)
@@ -264,7 +275,6 @@ def test_nn_model():
 
     # Check if evaluation results are within expected range
     evaluation_result = evaluate_model(model, test_dataset)
-    print(evaluation_result)
 
     min_expected_values = {
         "normalized_rmse": 0,
@@ -281,3 +291,5 @@ def test_nn_model():
         assert not np.isnan(
             evaluation_result[metric]
         ), f"Value of metric '{metric}' is NaN"
+
+test_nn_model()

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -235,8 +235,8 @@ def test_sklearn_model():
 
 
 def test_nn_model():
-    train_dataset = Dataset.load("maize_ES")
-    test_dataset = Dataset.load("maize_ES")
+    train_dataset = Dataset.load("maize_NL")
+    test_dataset = Dataset.load("maize_NL")
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
     # Initialize model, assumes that all features are in np.ndarray format
@@ -251,16 +251,16 @@ def test_nn_model():
     model.fit(
         train_dataset,
         batch_size=16,
-        epochs=20,
+        epochs=10,
         param_space={
-            "optimizer__lr": [0.0001, 0.00001],
-            "optimizer__weight_decay": [0.0001, 0.00001],
+            "lr": [0.0001, 0.00001],
+            "weight_decay": [0.0001, 0.00001],
         },
         device=device,
         scheduler_fn=scheduler_fn,
         **{
             "optimize_hyperparameters": True,
-            "validation_interval" : 5,
+            "validation_interval": 5,
             "loss_kwargs": {
                 "reduction": "mean",
             },
@@ -271,8 +271,11 @@ def test_nn_model():
         },
     )
 
-    test_preds, _ = model.predict(test_dataset)
-    assert test_preds.shape[0] == len(test_dataset)
+    # Test predict_batch
+    num_test_items = len(test_dataset)
+    test_data = [test_dataset[i] for i in range(min(num_test_items, 16))]
+    test_preds, _ = model.predict_batch(test_data)
+    assert test_preds.shape[0] == min(num_test_items, 16)
 
     # Check if evaluation results are within expected range
     evaluation_result = evaluate_model(model, test_dataset)


### PR DESCRIPTION
Tried to simplify nn-models code.
1. Skip early stopping and saving best model.
2. Hyperparameter optimization and confusion about what is in `settings`, `args` and `kwargs`.
3. `predict_batch` and `predict`.
4. Transforms code. Separating time series and static inputs must be done even when transforms is empty.
5. Add validation of AgML Workshop 2024 results.