### PR TITLE
init version for creating geoms

### DIFF
--- a/data_preparation/geometry_preparation.ipynb
+++ b/data_preparation/geometry_preparation.ipynb
@@ -1,0 +1,201 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Geometry data preparation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd \n",
+    "import pandas as pd\n",
+    "import os\n",
+    "from shapely.geometry import Polygon\n",
+    "\n",
+    "\n",
+    "# convert 3D geometries to 2D\n",
+    "def convert_to_2d(geom):\n",
+    "    if geom is not None:\n",
+    "        # Check if the geometry is a Polygon and contains Z-dimension\n",
+    "        if isinstance(geom, Polygon) and geom.has_z:\n",
+    "            # Convert to 2D by taking only the X and Y coordinates\n",
+    "            return Polygon([(x, y) for x, y, z in geom.exterior.coords])\n",
+    "        return geom  # Return as-is if already 2D\n",
+    "    return None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### load shapefiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "argentina = gpd.read_file('/app/dev/AgML/location_encoding/argentina/arg_adm_unhcr2017_shp/arg_admbnda_adm2_unhcr2017.shp')\n",
+    "australia = gpd.read_file('/app/dev/AgML/location_encoding/australia/Shapefiles/ABARES_regions_boundaries.shp')\n",
+    "brazil = gpd.read_file('/app/dev/AgML/location_encoding/brazil/bra_admbnda_adm2_ibge_2020.shp')\n",
+    "china = gpd.read_file('/app/dev/AgML/location_encoding/china/chn_admbnda_adm1_ocha_2020.shp')\n",
+    "eu = gpd.read_file('/app/dev/AgML/location_encoding/eu/NUTS_RG_03M_2016_4326.shp')\n",
+    "india = gpd.read_file('/app/dev/AgML/location_encoding/india/India_585districts_adm2.shp')\n",
+    "mali = gpd.read_file('/app/dev/AgML/location_encoding/mali/cmdt_boundaries/cmdt_boundary.shp')\n",
+    "mexico = gpd.read_file('/app/dev/AgML/location_encoding/mexico/INEGI Census/geometries/updated/00ent_edited.shp')\n",
+    "us = gpd.read_file('/app/dev/AgML/location_encoding/us/cb_2018_us_county_500k.shp')\n",
+    "\n",
+    "fewsnet = gpd.read_file('/app/dev/AgML/location_encoding/fewsnet/adm_shapefile_AgML_v0.1.shp')\n",
+    "fewsnet['country_iso'] = fewsnet['adm_id'].apply(lambda x: x[:2])# add country code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### create geometries: change path to main cybench crop path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- geometries are created from shapefile and attributed with adm_id\n",
+    "- choose crop to execute "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crop = 'wheat'  #maize, wheat\n",
+    "root_path = '/app/dev/AgML/cy_bench/cybench-data'\n",
+    "d = 'GeoJSON'  #geojson driver\n",
+    "\n",
+    "\n",
+    "# get list of 2-character iso, remove unique\n",
+    "iso = sorted(list(set(os.listdir(os.path.join(root_path, 'maize')) + \n",
+    "                      os.listdir(os.path.join(root_path, 'wheat')))))\n",
+    "\n",
+    "\n",
+    "# iterate country and save geometries\n",
+    "for country in iso:\n",
+    "\n",
+    "    try:\n",
+    "        country_path = os.path.join(root_path, crop, country)\n",
+    "\n",
+    "        if country == 'AR':\n",
+    "            argentina['adm_id'] = argentina['ADM2_PCODE']\n",
+    "            argentina['geometry'] = argentina['geometry'].apply(convert_to_2d)\n",
+    "            argentina[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)\n",
+    "            \n",
+    "        elif country == 'AU':\n",
+    "            australia[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)\n",
+    "            \n",
+    "        elif country == 'BR':\n",
+    "            brazil.crs = \"EPSG:4326\"  #set crs\n",
+    "            brazil['adm_id'] = brazil['ADM2_PCODE']\n",
+    "            brazil[['adm_id','geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)  \n",
+    "\n",
+    "        elif country == 'CN':\n",
+    "            china['adm_id'] = china['ADM1_PCODE']\n",
+    "            china[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)  \n",
+    "                  \n",
+    "        elif country == 'IN':\n",
+    "            india[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)    \n",
+    "                \n",
+    "        elif country == 'ML':\n",
+    "             mali[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)       \n",
+    "\n",
+    "        elif country == 'MX':\n",
+    "            mexico['adm_id'] = mexico['adm_id'].apply(lambda x: x[:2] + '-' + x[2:] if pd.notnull(x) else x)\n",
+    "            mexico[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)   \n",
+    "                                       \n",
+    "        elif country == 'US':\n",
+    "            us['adm_id'] = 'US-' + us['STATEFP'].astype(str) + '-'+ us['COUNTYFP'].astype(str)\n",
+    "            us[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d) \n",
+    "\n",
+    "        elif country in fewsnet['country_iso'].tolist():\n",
+    "            country_filtered = fewsnet[fewsnet['country_iso']== country]\n",
+    "            country_filtered[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)\n",
+    "\n",
+    "        elif country in eu['CNTR_CODE'].tolist():\n",
+    "            country_filtered = eu[eu['CNTR_CODE'].str.startswith(country)]\n",
+    "\n",
+    "            # find and filter highest nut level\n",
+    "            adm_id_highest = country_filtered['LEVL_CODE'].max()\n",
+    "            country_filtered = country_filtered[country_filtered['LEVL_CODE']==adm_id_highest]\n",
+    "            country_filtered['adm_id'] = country_filtered['NUTS_ID']\n",
+    "            country_filtered[['adm_id', 'geometry']].to_file(os.path.join(country_path, 'geometry.geojson'), driver=d)                \n",
+    "                                                              \n",
+    "\n",
+    "    except Exception as e:\n",
+    "        print(f\"{country} skipped due to {e}\")\n",
+    "        continue\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## checklist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 126,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## checkers\n",
+    "# adm_id, country, geometry\n",
+    "# crs should be consistent e.g 4326\n",
+    "# missing shapefiles for independent DE\n",
+    "# geodataframe or pandas df\n",
+    "# fewnet countries\n",
+    "\n",
+    "# gdown https://drive.google.com/uc?id=1KzgECw0xac04Mbdkaq5uMNuTvT4sOlt2\n",
+    "# for eu, fewsnet, usa, the shapefiles are downloaded from google drive: agml activities/snyf/predictor data preparation/shapefiles\n",
+    "# currently only MALI from fewsnet is used"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- first version script to create geojson geometries to include in cybench. 
- shapefiles used have been downloaded from gdrive
- geometries are created for each country
- for EU, best nuts level is used
- saved geometries contain adm_id and geometry column to facilitate merging with predictor/yield data.

Fixes #330