### PR TITLE
update README instructions to run benchmark

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
-          pip install flake8 pytest pytest-cov scikit-learn pandas numpy torch tqdm statsmodels pymannkendall tsai
+          pip install poetry
+          poetry install
 
           git clone https://github.com/BigDataWUR/sample_data.git ${GITHUB_WORKSPACE}/cybench/data
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
           export PYTHONPATH="${PYTHONPATH}:${GITHUB_WORKSPACE}"
-          pytest tests/*/test*
+          poetry run pytest tests/*/test*

--- a/README.md
+++ b/README.md
@@ -98,10 +98,9 @@ Run the following commands to install dependencies or requirements.
 pip install poetry
 cd AgML-CY-Bench
 poetry install
-
 ```
 
-#### Downloading dataset
+#### Downloading the sample dataset
 You can work with a small sample of the dataset by running
 
 ```
@@ -109,7 +108,7 @@ git clone https://github.com/BigDataWUR/sample_data.git cybench/data
 ```
 from AgML-CY-Bench folder.
 
-#### Running the benchmark
+#### Running a reduced version of the benchmark
 
 To check everything is set up correctly, run
 ```
@@ -121,7 +120,21 @@ To run the benchmark for many crops and countries, follow the steps for [install
 [requirements](#requirements) from the previous section  in a machine with significant amount of resources (memory and storage).
 
 Get the dataset from [Zenodo](https://doi.org/10.5281/zenodo.11502142).
-After downloading the dataset, unzip the data to `AgML-CY-Bench/cybench/data`.
+After downloading the dataset, move the unzipped data inside `AgML-CY-Bench/cybench/data` or
+`AgML-CY-Bench/cybench/data` points to the directory containing unzipped data.
+
+Unzip the downloaded data:
+```
+unzip cybench-data.zip -d <target_dir>
+```
+Move the data to the expected data path:
+```
+mv <target_dir>/* cybench/data
+```
+or create a symbolic link to the same effect:
+```
+ln -sf <target_dir> cybench/data
+```
 
 Run the benchmark on a dataset using
 ```

--- a/README.md
+++ b/README.md
@@ -92,34 +92,53 @@ git clone https://github.com/BigDataWUR/AgML-CY-Bench
 
 #### Requirements
 
-The benchmark results were produced in the following test environment:
+Create a virtual python environment and activate the environment. The exact step depends on whether you are using `conda` or `virtualenv`. See [this post] about why you need python environments. Example steps when using `conda`.
 
 ```
-Operating system: Ubuntu 18.04
-CPU: Intel Xeon Gold 6448Y (32 Cores)
-memory (RAM): 256GB
-disk storage: 2TB
-GPU: NVIDIA RTX A6000
+conda create --name agml-cybench python=3.12
+conda activate agml-cybench
+
 ```
 
-**Benchmark run time**
+Run the following commands to install dependencies or requirements.
 
-During the benchmark run with the baseline models, several countries were run in parallel, each in a GPU in a
-distributed cluster.
-The larger countries took approximately 18 hours to complete.
-If run sequentially in a single capable GPU, the whole benchmark should take 50-60 hours to complete.
+```
+pip install poetry
+cd AgML-CY-Bench
+poetry install
 
-**Software requirements**: Python 3.9.4, scikit-learn 1.4.2, PyTorch 2.3.0+cu118.
+```
 
 #### Downloading dataset
+You can work with a small sample of the dataset by running
 
-Get the dataset
-from [Zenodo](https://doi.org/10.5281/zenodo.11502142).
+```
+git clone https://github.com/BigDataWUR/sample_data.git cybench/data
+```
+from AgML-CY-Bench folder.
 
 #### Running the benchmark
 
-First write a model class `your_model` that extends the `BaseModel` class. The base model class definition is
-inside `models.model`.
+To check everything is set up correctly, run
+```
+poetry run python cybench/runs/run_benchmark -d maize_NL
+```
+
+### Running the full benchmark
+To run the benchmark for many crops and countries, follow the steps for [installation](#installation) and
+[requirements](#requirements) from the previous section  in a machine with significant amount of resources (memory and storage).
+
+Get the dataset from [Zenodo](https://doi.org/10.5281/zenodo.11502142).
+After downloading the dataset, unzip the data to `AgML-CY-Bench/cybench/data`.
+
+Run the benchmark for all datasets and models using
+```
+poetry run python cybench/runs/run_benchmark -d all
+```
+
+If you want to write your own model and compare performance with the benchmark,
+write a model class `your_model` that extends the `BaseModel` class.
+The base model class definition is inside `models.model`.
 
 ```
 from cybench.models.model import BaseModel
@@ -140,21 +159,22 @@ run_benchmark(run_name=run_name,
 
 ```
 
-### Dataset
-
-Dataset can be loaded by crop and (optionally by country).
-
-For example
+#### Reproducing the results
+The benchmark results were produced in the following test environment:
 
 ```
-dataset = Dataset.load("maize")
+Operating system: Ubuntu 18.04
+CPU: Intel Xeon Gold 6448Y (32 Cores)
+memory (RAM): 256GB
+disk storage: 2TB
+GPU: NVIDIA RTX A6000
 ```
 
-will load data for countries covered by the maize dataset. Maize data for the US can be loaded as follows:
+**Benchmark run time**
 
-```
-dataset = Dataset.load("maize_US")
-```
+During the benchmark run with the baseline models, several countries were run in parallel, each in a GPU in a
+distributed cluster. The larger countries took approximately 18 hours to complete.
+If run sequentially in a single capable GPU, the whole benchmark should take 50-60 hours to complete.
 
 #### Data sources
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can work with a small sample of the dataset by running
 ```
 git clone https://github.com/BigDataWUR/sample_data.git cybench/data
 ```
-from AgML-CY-Bench folder.
+from the `AgML-CY-Bench` folder.
 
 #### Running a reduced version of the benchmark
 
@@ -121,7 +121,7 @@ To run the benchmark for many crops and countries, follow the steps for [install
 
 Get the dataset from [Zenodo](https://doi.org/10.5281/zenodo.11502142).
 After downloading the dataset, move the unzipped data inside `AgML-CY-Bench/cybench/data` or
-`AgML-CY-Bench/cybench/data` points to the directory containing unzipped data.
+make sure `AgML-CY-Bench/cybench/data` points to the directory containing unzipped data.
 
 Unzip the downloaded data:
 ```
@@ -131,7 +131,7 @@ Move the data to the expected data path:
 ```
 mv <target_dir>/* cybench/data
 ```
-or create a symbolic link to the same effect:
+or create a symbolic link from `cybench/data` to the target directory:
 ```
 ln -sf <target_dir> cybench/data
 ```
@@ -192,8 +192,8 @@ See [tables inside `results_baselines`](results_baselines/tables/)
 
 #### Data sources
 
-| Crop Statistics                                                           | Shapefiles or administrative boundaries                              | Predictors, crop masks, crop calendars                                                     |
-|---------------------------------------------------------------------------|----------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| Crop Statistics | Shapefiles or administrative boundaries | Predictors, crop masks, crop calendars |
+|-----------------|-----------------------------------------|----------------------------------------|
 | [Africa from FEWSNET](data_preparation/crop_statistics_FEWSNET/README.md) | [Africa from FEWSNET](data_preparation/shapefiles_FEWSNET/README.md) | Weather: [AgERA5](data_preparation/global_AgERA5/README.md)                                |
 | [Mali](data_preparation/crop_statistics_ML/README.md) (1)                 | Use Africa shapefiles from FEWSNET                                   | Soil: [WISE soil data](data_preparation/global_soil_WISE/README.md)                        |
 | [Argentina](data_preparation/crop_statistics_AR/README.md)                | [Argentina](data_preparation/shapefiles_AR/README.md)                | Soil moisture: [GLDAS](data_preparation/global_soil_moisture_GLDAS/README.md)              |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ unzip cybench-data.zip -d <target_dir>
 ```
 Move the data to the expected data path:
 ```
-mv <target_dir>/* cybench/data
+mv <target_dir> cybench/data
 ```
 or create a symbolic link from `cybench/data` to the target directory:
 ```

--- a/README.md
+++ b/README.md
@@ -92,14 +92,6 @@ git clone https://github.com/BigDataWUR/AgML-CY-Bench
 
 #### Requirements
 
-Create a virtual python environment and activate the environment. The exact step depends on whether you are using `conda` or `virtualenv`. See [this post] about why you need python environments. Example steps when using `conda`.
-
-```
-conda create --name agml-cybench python=3.12
-conda activate agml-cybench
-
-```
-
 Run the following commands to install dependencies or requirements.
 
 ```
@@ -121,7 +113,7 @@ from AgML-CY-Bench folder.
 
 To check everything is set up correctly, run
 ```
-poetry run python cybench/runs/run_benchmark -d maize_NL
+poetry run python cybench/runs/run_benchmark.py -d maize_NL -m test
 ```
 
 ### Running the full benchmark
@@ -131,9 +123,9 @@ To run the benchmark for many crops and countries, follow the steps for [install
 Get the dataset from [Zenodo](https://doi.org/10.5281/zenodo.11502142).
 After downloading the dataset, unzip the data to `AgML-CY-Bench/cybench/data`.
 
-Run the benchmark for all datasets and models using
+Run the benchmark on a dataset using
 ```
-poetry run python cybench/runs/run_benchmark -d all
+poetry run python cybench/runs/run_benchmark.py -d maize_NL
 ```
 
 If you want to write your own model and compare performance with the benchmark,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ benchmark is called CY-Bench (crop yield benchmark).
 
 * [Overview](#overview)
 * [Getting started](#getting-started)
-* [Dataset](#dataset)
+* [Running the full benchmark](#running-the-full-benchmark)
 * [Leaderboard](#leaderboard)
 * [How to cite](#how-to-cite)
 * [How to contribute](#how-to-contribute)
@@ -155,17 +155,23 @@ class MyModel(BaseModel):
 
 run_name = <run_name>
 dataset_name = "maize_US"
-run_benchmark(run_name=run_name, 
-              model_name="my_model",
-              model_constructor=MyModel,
-              model_init_kwargs: <int args>,
-              model_fit_kwargs: <fit params>,
-              dataset_name=dataset_name)
+result = run_benchmark(run_name=run_name, 
+                       model_name="my_model",
+                       model_constructor=MyModel,
+                       model_init_kwargs: <int args>,
+                       model_fit_kwargs: <fit params>,
+                       dataset_name=dataset_name)
+
+metrics = ["normalized_rmse", "mape", "r2"]
+df_metrics = result["df_metrics"].reset_index()
+print(df_metrics.groupby("model").agg({ m : "mean" for m in metrics }))
 
 ```
 
-#### Reproducing the results
-The benchmark results were produced in the following test environment:
+Compare the results (values of metrics for the specified dataset) with [the baseline results](results_baselines/tables/) for the same dataset.
+
+#### Reproducing the baseline results
+The baseline results were produced in the following test environment:
 
 ```
 Operating system: Ubuntu 18.04
@@ -180,6 +186,9 @@ GPU: NVIDIA RTX A6000
 During the benchmark run with the baseline models, several countries were run in parallel, each in a GPU in a
 distributed cluster. The larger countries took approximately 18 hours to complete.
 If run sequentially in a single capable GPU, the whole benchmark should take 50-60 hours to complete.
+
+### Leaderboard
+See [tables inside `results_baselines`](results_baselines/tables/)
 
 #### Data sources
 
@@ -201,9 +210,6 @@ If run sequentially in a single capable GPU, the whole benchmark should take 50-
 
 2: Germany data is also included in the EU dataset, but there most of the data fails coherence tests (e.g. yield =
 production / harvest_area)
-
-### Leaderboard
-See [baseline results](results_baselines/tables/)
 
 ### How to cite
 

--- a/cybench/runs/run_benchmark.py
+++ b/cybench/runs/run_benchmark.py
@@ -324,6 +324,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog="run_benchmark.py", description="Run cybench")
     parser.add_argument("-r", "--run-name")
     parser.add_argument("-d", "--dataset-name")
+    parser.add_argument("-m", "--mode")
     args = parser.parse_args()
     dataset_name = args.dataset_name
     assert dataset_name is not None
@@ -333,23 +334,30 @@ if __name__ == "__main__":
     else:
         run_name = dataset_name
 
-    # skipping some models
-    baseline_models = [
-        "AverageYieldModel",
-        "LinearTrend",
-        "SklearnRidge",
-        "RidgeRes",
-        "LSTM",
-        "LSTMRes",
-    ]
-    # override epochs for nn-models
-    nn_models_epochs = 5
-    results = run_benchmark(
-        run_name=run_name,
-        dataset_name=dataset_name,
-        baseline_models=baseline_models,
-        nn_models_epochs=nn_models_epochs,
-    )
+    if (args.mode is not None) and args.mode == "test":
+        # skipping some models
+        baseline_models = [
+            "AverageYieldModel",
+            "LinearTrend",
+            "SklearnRidge",
+            "RidgeRes",
+            "LSTM",
+            "LSTMRes",
+        ]
+        # override epochs for nn-models
+        nn_models_epochs = 5
+        results = run_benchmark(
+            run_name=run_name,
+            dataset_name=dataset_name,
+            baseline_models=baseline_models,
+            nn_models_epochs=nn_models_epochs,
+        )
+    else:
+        results = run_benchmark(
+            run_name=run_name,
+            dataset_name=dataset_name
+        )
+
     df_metrics = results["df_metrics"].reset_index()
     print(
         df_metrics.groupby("model").agg(

--- a/cybench/runs/run_benchmark.py
+++ b/cybench/runs/run_benchmark.py
@@ -129,9 +129,7 @@ def run_benchmark(
         model_name not in BASELINE_MODELS
     ), f"Model name {model_name} already occurs in the baseline"
 
-    model_constructors = {
-        k: _BASELINE_MODEL_CONSTRUCTORS[k] for k in baseline_models
-    }
+    model_constructors = {k: _BASELINE_MODEL_CONSTRUCTORS[k] for k in baseline_models}
 
     models_init_kwargs = defaultdict(dict)
     for name in baseline_models:
@@ -155,7 +153,7 @@ def run_benchmark(
     dataset = Dataset.load(dataset_name)
 
     all_years = sorted(dataset.years)
-    if (sel_years is not None):
+    if sel_years is not None:
         assert all([yr in all_years for yr in sel_years])
     else:
         sel_years = all_years
@@ -353,10 +351,7 @@ if __name__ == "__main__":
             nn_models_epochs=nn_models_epochs,
         )
     else:
-        results = run_benchmark(
-            run_name=run_name,
-            dataset_name=dataset_name
-        )
+        results = run_benchmark(run_name=run_name, dataset_name=dataset_name)
 
     df_metrics = results["df_metrics"].reset_index()
     print(


### PR DESCRIPTION
Updated README. `run_benchmark.py` script has a test mode for running a reduced version of the benchmark (skipping most of the NN models).